### PR TITLE
fix: support memory64 flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,7 @@ with the following improvements:
 
 ## Dev Log
 
-* `2024-04-17` [`699dbbc`](https://github.com/permaweb/wasm-json-toolkit/commit/699dbbcaab406cc657b16e82a850e385de417f84) Add 5 missing opcodes
+* `2024-04-17` [`699dbbc`](https://github.com/permaweb/wasm-json-toolkit/commit/699dbbcaab406cc657b16e82a850e385de417f84)
+Add 5 missing opcodes
+* `2024-04-17` [`3cafd9f`](https://github.com/permaweb/wasm-json-toolkit/commit/3cafd9fd9289484ee9a049a139e36bbd79effcf6)
+Support threaded and memory64 memory flags

--- a/json2wasm.js
+++ b/json2wasm.js
@@ -245,8 +245,8 @@ _exports.typeGenerators = {
    * @param {Stream} stream
    */
   memory: (json, stream) => {
-    leb.unsigned.write(Number(json.maximum !== undefined), stream) // the flags
-    leb.unsigned.write(json.intial, stream)
+    leb.unsigned.write(json.flags, stream)
+    leb.unsigned.write(json.initial, stream)
 
     if (json.maximum !== undefined) {
       leb.unsigned.write(json.maximum, stream)

--- a/wasm2json.js
+++ b/wasm2json.js
@@ -346,8 +346,8 @@ _exports.typeParsers = {
   memory: (stream) => {
     const limits = {}
     limits.flags = leb.unsigned.readBn(stream).toNumber()
-    limits.intial = leb.unsigned.readBn(stream).toNumber()
-    if (limits.flags === 1) {
+    limits.initial = leb.unsigned.readBn(stream).toNumber()
+    if (limits.flags % 2 === 1) {
       limits.maximum = leb.unsigned.readBn(stream).toNumber()
     }
     return limits


### PR DESCRIPTION
previously only flags values of `0x00` and `0x01` were expected, but `0x04` and `0x05` are defined by memory64.

See more: https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md#binary-format